### PR TITLE
Updates to exploredb functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WRDSMerger"
 uuid = "59d27aa3-834e-4232-9046-52ef43e86786"
 authors = ["junder873 <junder873@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ WRDSMerger.default_tables["comp_fundq"] = "compa_fundq"
 ...
 ```
 
+### ODBC vs LibPQ
+
+The two largest packages I am aware of for connecting to a Postgres database in Lulia are [ODBC.jl](https://github.com/JuliaDatabases/ODBC.jl) and [LibPQ.jl](https://github.com/invenia/LibPQ.jl). Both of these have various advantages.
+
+Starting with LibPQ, adding LibPQ to your project is the full installation process. To use ODBC, an extra driver, with extra setup, needs to occur before use. In addition, as far as I can tell, LibPQ does not have a limit on length of query. Some functions in this package (such as `crsp_data`) create exceptionally long queries to reduce the total amount of data downloaded, which LibPQ handles easily.
+
+For ODBC, it is considerably faster at converting data to a DataFrame. For example, downloading the full CRSP Stockfile (`crsp.dsf`, which includes returns for every stock for each day and is about 100 million rows), takes about 4 minutes to download and make into a DataFrame with ODBC on a gigabit connection. LibPQ takes about 24 minutes. Most of this difference appears to be type instability while converting the LibPQ result to a DataFrame, since the initial LibPQ result only takes a minute and `@time` reports 80% garbage collection time. ODBC also stores your password separately (in the driver settings) making it a little easier to share a project without compromising your password.
+
 ## Links Between WRDS Identifiers
 
 A common task is linking two tables in WRDS. The most common identifiers are Permno (used in CRSP datasets), Cusip (used in a variety of datasets, and its historical version, NCusip), GVKey (Compustat datasets), and IBES Tickers (used in IBES). This package provides the function `link_identifiers` to link between these different identifiers (CIK and normal Tickers as well). It also provides a number of types to make it clear what identifier is being used. Most of these links (the only exception I know of is GVKey and CIK) are only valid for a specific range of dates. Therefore, you would pass the function some a vector of the initial type, vector of dates, and the types that you want to link to.

--- a/src/exploreDB.jl
+++ b/src/exploreDB.jl
@@ -1,7 +1,6 @@
 """
-    function list_libraries(conn::Union{LibPQ.Connection, 
-        DBInterface.Connection}
-    )
+    list_libraries(conn::Union{LibPQ.Connection, DBInterface.Connection})
+
 Load the list of Postgres schemata
 the user has permission to access
 """
@@ -23,9 +22,8 @@ end
 
 
 """
-    function check_schema_perms(conn::Union{LibPQ.Connection, 
-        DBInterface.Connection}, library::String
-    )::Bool
+    check_schema_perms(conn::Union{LibPQ.Connection, DBInterface.Connection}, library::String)
+
 Verify that the user can access a schema
 """
 function check_schema_perms(conn::Union{LibPQ.Connection, DBInterface.Connection}, library::String)
@@ -44,9 +42,7 @@ function check_schema_perms(conn::Union{LibPQ.Connection, DBInterface.Connection
 end
 
 """
-    function list_tables(conn::Union{LibPQ.Connection, 
-            DBInterface.Connection}, library::String
-    )
+    list_tables(conn::Union{LibPQ.Connection, DBInterface.Connection}, library::String)
 
 List all of the views/tables/foreign tables within a schema
 """
@@ -59,9 +55,7 @@ function list_tables(conn::Union{LibPQ.Connection, DBInterface.Connection}, libr
 end
 
 """
-    function approx_row_count(conn::Union{LibPQ.Connection,
-        DBInterface.Connection}, library::String, table::String
-    )
+    approx_row_count(conn::Union{LibPQ.Connection, DBInterface.Connection}, library::String, table::String)
 
 Get an approximate count of the number of rows in a table
 """
@@ -80,10 +74,7 @@ end
 
 
 """
-    function describe_table(conn::Union{LibPQ.Connection, 
-        DBInterface.Connection}, library::String, 
-        table::String
-    )
+    describe_table(conn::Union{LibPQ.Connection, DBInterface.Connection}, library::String, table::String)
 
 Get a table's description (row count, columns, column types)
 """
@@ -105,14 +96,19 @@ end
 
 
 """
-    function get_table(conn::Union{LibPQ.Connection, 
-        DBInterface.Connection}, library::String, table::String;
-        obs::Int = nothing, offset::Int = 0, cols = nothing
-    )
+    get_table(
+                    conn::Union{LibPQ.Connection, DBInterface.Connection},
+                    library::String,
+                    table::String;
+                    obs::Union{Nothing, Int} = nothing,
+                    offset::Int = 0,
+                    cols = nothing
+                )
 
 Create a DataFrame from a table
 """
-function get_table(conn::Union{LibPQ.Connection, DBInterface.Connection},
+function get_table(
+                    conn::Union{LibPQ.Connection, DBInterface.Connection},
                     library::String,
                     table::String;
                     obs::Union{Nothing, Int} = nothing,
@@ -132,13 +128,16 @@ end
 
 
 """
-    function raw_sql(conn::Union{LibPQ.Connection, 
-        DBInterface.Connection},
+    raw_sql(
+        conn::Union{LibPQ.Connection, DBInterface.Connection},
         query::String
     )
+
 Executes raw sql code, and converts code to a DataFrame
 """
-function raw_sql(conn::Union{LibPQ.Connection, DBInterface.Connection},
-                query::String)
+function raw_sql(
+    conn::Union{LibPQ.Connection, DBInterface.Connection},
+    query::String
+)
     return run_sql_query(conn, query)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,7 @@ function modify_col!(df, col)
             df[!, col] = parse_datetime.(df[:, col])
         end
     end
-    if !all_missing && any(ismissing.(df[:, col]))
+    if !all_missing && !any(ismissing.(df[:, col]))
         disallowmissing!(df, col)
     end
 end


### PR DESCRIPTION
The exploredb functions only use `execute` while other functions use `run_sql_query`, which allows for ODBC or LibPQ as execution. I have also found they occasionally run into errors because of this difference.

I think it is also worthwhile to improve how `run_sql_query` works to make it automatically adjust types if possible (for dates, times, etc.)